### PR TITLE
Simplify Service Registry

### DIFF
--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -20,13 +20,8 @@ func TestJoin_registers_all_nodes(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("test registery contains expected services", func(t *testing.T) {
-		expected := []string{
-			"/services/ping",
-		}
-		require.Equal(t, expected, c.Registry.Services())
-	})
-
-	// TODO
-	t.Run("test registery contains expected nodes per service", func(t *testing.T) {
+		services, err := c.Registry.Services(ctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, services["ping"])
 	})
 }

--- a/cluster/service_registry.go
+++ b/cluster/service_registry.go
@@ -56,7 +56,6 @@ func (sr *ServiceRegistry) Register(ctx context.Context, serviceName, nodeName s
 var defaultGetOptions = &client.GetOptions{
 	Recursive: true,
 	Sort:      true,
-	Quorum:    true,
 }
 
 func (sr *ServiceRegistry) Services(ctx context.Context) (map[string][]Node, error) {


### PR DESCRIPTION
# What

This PR simplifies the service registry in the following ways:
- Removed the watcher, and read on each call to lookup services
- Update tests to accept dynamic hostnames
- Remove quoram read option