### PR TITLE
ServiceRegistry Unit Tests

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"go.etcd.io/etcd/embed"
 )
@@ -22,7 +23,11 @@ func Join(ctx context.Context, cfg Config) (*Cluster, error) {
 		return nil, err
 	}
 
-	if err := registry.Register(ctx, cfg.ServiceName, cfg.NodeName, cfg.Port); err != nil {
+	host, err := os.Hostname()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read hostname: %w", err)
+	}
+	if err := registry.Register(ctx, cfg.ServiceName, cfg.NodeName, host, cfg.Port); err != nil {
 		return nil, err
 	}
 

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestJoin_registers_all_nodes(t *testing.T) {
+func TestJoin(t *testing.T) {
 	cfg, err := ConfigFromFile("./testdata/ping.yml")
 	require.NoError(t, err)
 

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -12,12 +11,13 @@ func TestJoin(t *testing.T) {
 	cfg, err := ConfigFromFile("./testdata/ping.yml")
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// TODO add more nodes to the test
 	c, err := Join(ctx, cfg)
 	require.NoError(t, err)
+	defer c.Close()
 
 	t.Run("test registery contains expected services", func(t *testing.T) {
 		services, err := c.Registry.Services(ctx)

--- a/cluster/service_registry.go
+++ b/cluster/service_registry.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"go.etcd.io/etcd/client"
@@ -33,12 +32,7 @@ func NewServiceRegistry(ctx context.Context, etcdAddr string) (*ServiceRegistry,
 	}, nil
 }
 
-func (sr *ServiceRegistry) Register(ctx context.Context, serviceName, nodeName string, port int) error {
-	host, err := os.Hostname()
-	if err != nil {
-		return fmt.Errorf("failed to read hostname: %w", err)
-	}
-
+func (sr *ServiceRegistry) Register(ctx context.Context, serviceName, nodeName, host string, port int) error {
 	node := Node{Address: host, Port: port}
 	val, err := json.Marshal(node)
 	if err != nil {

--- a/cluster/service_registry_test.go
+++ b/cluster/service_registry_test.go
@@ -1,0 +1,143 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/client"
+	"go.etcd.io/etcd/embed"
+)
+
+var TestEtcdAddr string
+
+func TestMain(m *testing.M) {
+	addr, cleanup := startTestEtcd()
+	defer cleanup()
+	TestEtcdAddr = addr
+
+	os.Exit(m.Run())
+}
+
+func TestServiceRegistry_Register(t *testing.T) {
+	cleanEtcdDir(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sr, err := NewServiceRegistry(ctx, TestEtcdAddr)
+	require.NoError(t, err)
+
+	err = sr.Register(context.Background(), "foo", "node1", "host", 8000)
+	require.NoError(t, err)
+	err = sr.Register(context.Background(), "foo", "node2", "host2", 8000)
+	require.NoError(t, err)
+	err = sr.Register(context.Background(), "bar", "node3", "host3", 3000)
+	require.NoError(t, err)
+
+	t.Run("test multiple nodes registered for foo", func(t *testing.T) {
+		key := filepath.Join(servicesPrefix, "foo")
+		res, err := sr.kapi.Get(ctx, key, defaultGetOptions)
+		require.NoError(t, err)
+
+		require.Len(t, res.Node.Nodes, 2)
+
+		expected := []string{
+			`{"address":"host", "port":8000}`,
+			`{"address":"host2", "port":8000}`,
+		}
+		for i, node := range res.Node.Nodes {
+			require.JSONEq(t, expected[i], node.Value)
+		}
+	})
+
+	t.Run("test one node registered for bar", func(t *testing.T) {
+		key := filepath.Join(servicesPrefix, "bar")
+		res, err := sr.kapi.Get(ctx, key, defaultGetOptions)
+		require.NoError(t, err)
+
+		require.Len(t, res.Node.Nodes, 1)
+
+		expected := `{"address":"host3", "port":3000}`
+		require.JSONEq(t, expected, res.Node.Nodes[0].Value)
+	})
+}
+
+func TestServiceRegistry_Services(t *testing.T) {
+	cleanEtcdDir(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sr, err := NewServiceRegistry(ctx, TestEtcdAddr)
+	require.NoError(t, err)
+
+	key := filepath.Join(servicesPrefix, "foo", "node1")
+	_, err = sr.kapi.Set(ctx, key, `{"address":"host", "port":8000}`, nil)
+	require.NoError(t, err)
+	key = filepath.Join(servicesPrefix, "foo", "node2")
+	_, err = sr.kapi.Set(ctx, key, `{"address":"host2", "port":8000}`, nil)
+	require.NoError(t, err)
+	key = filepath.Join(servicesPrefix, "bar", "node3")
+	_, err = sr.kapi.Set(ctx, key, `{"address":"host3", "port":3000}`, nil)
+	require.NoError(t, err)
+
+	actual, err := sr.Services(ctx)
+	require.NoError(t, err)
+
+	expected := map[string][]Node{
+		"foo": {
+			{Address: "host", Port: 8000},
+			{Address: "host2", Port: 8000},
+		},
+		"bar": {
+			{Address: "host3", Port: 3000},
+		},
+	}
+	require.Equal(t, expected, actual)
+}
+
+func startTestEtcd() (string, func()) {
+	// TODO set no etcd logs in tests
+	cfg := embed.NewConfig()
+
+	tmp, err := ioutil.TempDir("", "test_etcd")
+	cfg.Dir = tmp
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	e, err := startEmbeddedEtcd(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	addr := cfg.LCUrls[0].String()
+	return addr, func() {
+		e.Close()
+		<-e.Server.StopNotify()
+		os.RemoveAll(tmp)
+	}
+}
+
+func cleanEtcdDir(t *testing.T) {
+	c, err := client.New(client.Config{Endpoints: []string{TestEtcdAddr}})
+	require.NoError(t, err)
+	kapi := client.NewKeysAPI(c)
+	// wipe services dir for every test
+	_, err = kapi.Delete(context.Background(), servicesPrefix, &client.DeleteOptions{
+		Recursive: true,
+		Dir:       true,
+	})
+
+	var cErr client.Error
+	if errors.As(err, &cErr) && cErr.Code == client.ErrorCodeKeyNotFound {
+		return
+	}
+	require.NoError(t, err)
+}

--- a/cluster/service_registry_test.go
+++ b/cluster/service_registry_test.go
@@ -103,7 +103,6 @@ func TestServiceRegistry_Services(t *testing.T) {
 }
 
 func startTestEtcd() (string, func()) {
-	// TODO set no etcd logs in tests
 	cfg := embed.NewConfig()
 
 	tmp, err := ioutil.TempDir("", "test_etcd")

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/coreos/bbolt v1.3.3 // indirect
-	github.com/coreos/etcd v3.3.17+incompatible // indirect
+	github.com/coreos/etcd v3.3.17+incompatible
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/gogo/protobuf v1.3.1 // indirect


### PR DESCRIPTION
# What

This PR adds unit tests for the service registry. The real feat here is the setup of etcd for tests. After many tries, I was not able to get a new etcd per test to start and clean up.  A couple of things I tried are:
- `defer etcd.Server.Close()` after every test
- Add delay after cleanup to ensure port fd was released
- Use a different tmp dir per etcd 

The method that ended up working was starting one test etcd and reusing it between tests. 