### PR TITLE
add initial key value store

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -10,6 +10,7 @@ import (
 
 type Cluster struct {
 	Registry *ServiceRegistry
+	Store    *KVStore
 	etcd     *embed.Etcd
 }
 

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"go.etcd.io/etcd/client"
-	"path/filepath"
 )
 
 const storePrefix = "store"

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -3,23 +3,22 @@ package cluster
 import (
 	"context"
 	"fmt"
-	"go.etcd.io/etcd/client"
+	"github.com/coreos/etcd/clientv3"
 )
 
-const storePrefix = "store"
-
 type KVStore struct {
-	kapi client.KeysAPI
+	kv clientv3.KV
 }
 
 func NewKVStore(ctx context.Context, etcdAddr string) (*KVStore, error) {
-	cfg := client.Config{Endpoints: []string{etcdAddr}}
-	c, err := client.New(cfg)
+	cfg := clientv3.Config{Endpoints: []string{etcdAddr}}
+	c, err := clientv3.New(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create etcd client from addr %v: %w", etcdAddr, err)
 	}
+	defer c.Close()
 
 	return &KVStore{
-		kapi: client.NewKeysAPI(c),
+		kv: clientv3.NewKV(c),
 	}, nil
 }

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -1,0 +1,26 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"go.etcd.io/etcd/client"
+	"path/filepath"
+)
+
+const storePrefix = "store"
+
+type KVStore struct {
+	kapi client.KeysAPI
+}
+
+func NewKVStore(ctx context.Context, etcdAddr string) (*KVStore, error) {
+	cfg := client.Config{Endpoints: []string{etcdAddr}}
+	c, err := client.New(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create etcd client from addr %v: %w", etcdAddr, err)
+	}
+
+	return &KVStore{
+		kapi: client.NewKeysAPI(c),
+	}, nil
+}

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -3,7 +3,7 @@ package cluster
 import (
 	"context"
 	"fmt"
-	"github.com/coreos/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3"
 )
 
 type KVStore struct {
@@ -16,7 +16,6 @@ func NewKVStore(ctx context.Context, etcdAddr string) (*KVStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create etcd client from addr %v: %w", etcdAddr, err)
 	}
-	defer c.Close()
 
 	return &KVStore{
 		kv: clientv3.NewKV(c),

--- a/cluster/store_test.go
+++ b/cluster/store_test.go
@@ -1,0 +1,13 @@
+package cluster
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestNewKVStore(t *testing.T) {
+	store, err := NewKVStore(context.Background(), "")
+	require.NoError(t, err)
+	require.NotNil(t, store)
+}


### PR DESCRIPTION
This is the base for adding a key value store. I decided to go with the [etcd design from the report.](https://docs.google.com/document/d/1uyd7m1bkvPEv_cIDi6jEcFdncJZUq7Y0_MvYxPoMtt4/edit#heading=h.bxqk6xmh1sgu)

This is blatantly cargo culting @JackyChiu 's service registry setup.