### PR TITLE
Watch Service Functionality

### DIFF
--- a/cluster/registry.go
+++ b/cluster/registry.go
@@ -16,6 +16,7 @@ const servicesPrefix = "services"
 type Registry interface {
 	Register(ctx context.Context, serviceName, nodeName, host string, port int) error
 	Services(ctx context.Context) (map[string][]Node, error)
+	WatchService(ctx context.Context, serviceName string) chan []Node
 }
 
 type Node struct {

--- a/cluster/registry.go
+++ b/cluster/registry.go
@@ -25,7 +25,7 @@ type Node struct {
 }
 
 type etcdRegistry struct {
-	KV      clientv3.KV
+	kv      clientv3.KV
 	watcher clientv3.Watcher
 }
 
@@ -40,7 +40,7 @@ func newEtcdRegistry(ctx context.Context, etcdAddr string) (*etcdRegistry, error
 	}
 
 	return &etcdRegistry{
-		KV:      clientv3.NewKV(c),
+		kv:      clientv3.NewKV(c),
 		watcher: clientv3.NewWatcher(c),
 	}, nil
 }
@@ -53,7 +53,7 @@ func (er *etcdRegistry) Register(ctx context.Context, serviceName, nodeName, hos
 	}
 
 	key := filepath.Join(servicesPrefix, serviceName, nodeName)
-	if _, err = er.KV.Put(ctx, key, string(val)); err != nil {
+	if _, err = er.kv.Put(ctx, key, string(val)); err != nil {
 		return fmt.Errorf("failed to register node: %w", err)
 	}
 
@@ -66,7 +66,7 @@ var defaultGetOptions = []clientv3.OpOption{
 }
 
 func (er *etcdRegistry) Services(ctx context.Context) (map[string][]Node, error) {
-	res, err := er.KV.Get(ctx, servicesPrefix, defaultGetOptions...)
+	res, err := er.kv.Get(ctx, servicesPrefix, defaultGetOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get services from etcd: %w", err)
 	}
@@ -122,7 +122,7 @@ func (er *etcdRegistry) WatchService(ctx context.Context, serviceName string) ch
 
 func (er *etcdRegistry) nodes(ctx context.Context, serviceName string) ([]Node, error) {
 	key := filepath.Join(servicesPrefix, serviceName)
-	res, err := er.KV.Get(ctx, key, defaultGetOptions...)
+	res, err := er.kv.Get(ctx, key, defaultGetOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get services from etcd: %w", err)
 	}

--- a/cluster/registry_test.go
+++ b/cluster/registry_test.go
@@ -57,7 +57,7 @@ func (suite *EtcdDependentSuite) TestEtcdRegistry_Register() {
 
 	t.Run("test multiple nodes registered for foo", func(t *testing.T) {
 		key := filepath.Join(servicesPrefix, "foo")
-		res, err := sr.KV.Get(ctx, key, defaultGetOptions...)
+		res, err := sr.kv.Get(ctx, key, defaultGetOptions...)
 		require.NoError(t, err)
 
 		require.Len(t, res.Kvs, 2)
@@ -73,7 +73,7 @@ func (suite *EtcdDependentSuite) TestEtcdRegistry_Register() {
 
 	t.Run("test one node registered for bar", func(t *testing.T) {
 		key := filepath.Join(servicesPrefix, "bar")
-		res, err := sr.KV.Get(ctx, key, defaultGetOptions...)
+		res, err := sr.kv.Get(ctx, key, defaultGetOptions...)
 		require.NoError(t, err)
 
 		require.Len(t, res.Kvs, 1)
@@ -98,13 +98,13 @@ func (suite *EtcdDependentSuite) TestEtcdRegistry_Services() {
 	require.NoError(t, err)
 
 	key := filepath.Join(servicesPrefix, "foo", "node1")
-	_, err = sr.KV.Put(ctx, key, `{"address":"host", "port":8000}`)
+	_, err = sr.kv.Put(ctx, key, `{"address":"host", "port":8000}`)
 	require.NoError(t, err)
 	key = filepath.Join(servicesPrefix, "foo", "node2")
-	_, err = sr.KV.Put(ctx, key, `{"address":"host2", "port":8000}`)
+	_, err = sr.kv.Put(ctx, key, `{"address":"host2", "port":8000}`)
 	require.NoError(t, err)
 	key = filepath.Join(servicesPrefix, "bar", "node3")
-	_, err = sr.KV.Put(ctx, key, `{"address":"host3", "port":3000}`)
+	_, err = sr.kv.Put(ctx, key, `{"address":"host3", "port":3000}`)
 	require.NoError(t, err)
 
 	actual, err := sr.Services(ctx)
@@ -134,7 +134,7 @@ func (suite *EtcdDependentSuite) TestEtcdRegistry_WatchService() {
 	nodesChan := sr.WatchService(ctx, "foo")
 
 	key := filepath.Join(servicesPrefix, "foo", "node1")
-	_, err = sr.KV.Put(ctx, key, `{"address":"host", "port":8000}`)
+	_, err = sr.kv.Put(ctx, key, `{"address":"host", "port":8000}`)
 	require.NoError(t, err)
 
 	require.Equal(t, []Node{
@@ -142,7 +142,7 @@ func (suite *EtcdDependentSuite) TestEtcdRegistry_WatchService() {
 	}, <-nodesChan)
 
 	key = filepath.Join(servicesPrefix, "foo", "node3")
-	_, err = sr.KV.Put(ctx, key, `{"address":"host3", "port":3000}`)
+	_, err = sr.kv.Put(ctx, key, `{"address":"host3", "port":3000}`)
 	require.NoError(t, err)
 
 	require.Equal(t, []Node{

--- a/cluster/rpc_test.go
+++ b/cluster/rpc_test.go
@@ -23,6 +23,10 @@ func (m *mockRegistry) Services(ctx context.Context) (map[string][]Node, error) 
 	return m.services, m.err
 }
 
+func (m *mockRegistry) WatchService(ctx context.Context, serviceName string) chan []Node {
+	return make(chan []Node)
+}
+
 func TestNewClient(t *testing.T) {
 	rpc.HandleHTTP()
 	ts := http.Server{}


### PR DESCRIPTION
# What

This PR introduces a new method to the Registry interface. The functionality is to be able to watch for changes for a service and receive the updated list of nodes for each change event. 

# Why

The use case is general, but an immediate use case is for the RPC client. The RPC client should know if there are additional nodes or lost nodes in the service cluster in order to pick a new node to connect to. This results in a rebalancing of clients to nodes. 

# How

The implementation uses the Watch functionality of etcd. However, it will only provide individual events. What we actually want is a new up to date list of the nodes. This requires us to ask etcd for the new list every time a change occurs. It's not efficient but it's what we would want functionality wise. 

Please give opinions and feedback on anything mentioned here. 