### PR TITLE
Client Side Load Balancing 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  errcheck:
+    ignore: fmt:.*,io/ioutil:^Read.*,Write

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	go test -v --race ./... -timeout=25s
+	go test -v --race ./... -timeout=35s
 
 lint:
 	gofmt -w -s */**.go

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	go test -v --race ./... -timeout=15s
+	go test -v --race ./... -timeout=25s
 
 lint:
 	gofmt -w -s */**.go

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -19,6 +19,7 @@ type Cluster struct {
 	Store    *KVStore
 	client   *clientv3.Client
 	etcd     *embed.Etcd
+	host     string
 }
 
 func Join(ctx context.Context, cfg Config) (*Cluster, error) {
@@ -62,6 +63,7 @@ func Join(ctx context.Context, cfg Config) (*Cluster, error) {
 		Registry: registry,
 		client:   client,
 		etcd:     e,
+		host:     host,
 	}, nil
 }
 
@@ -113,6 +115,10 @@ func (c *Cluster) Close() error {
 	c.etcd.Close()
 	<-c.etcd.Server.StopNotify()
 	return nil
+}
+
+func (c *Cluster) NewClient(serviceName string) (*Client, error) {
+	return newClient(c.host, serviceName, c.Registry)
 }
 
 func startEmbeddedEtcd(cfg *embed.Config) (*embed.Etcd, error) {

--- a/cluster/registry_test.go
+++ b/cluster/registry_test.go
@@ -162,7 +162,7 @@ func (suite *EtcdDependentSuite) TestEtcdRegistry_WatchService() {
 
 	nodesChan := sr.WatchService(ctx, "foo")
 
-	t.Run("channel returns the inital list of nodes before channel is created", func(t *testing.T) {
+	t.Run("channel returns the initial list of nodes before channel is created", func(t *testing.T) {
 		require.Equal(t, []Node{
 			{Address: "host", Port: 8000},
 		}, <-nodesChan)

--- a/cluster/rpc.go
+++ b/cluster/rpc.go
@@ -3,8 +3,11 @@ package cluster
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"hash/fnv"
 	"net/rpc"
+	"strconv"
+	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -38,6 +41,94 @@ func NewClient(serviceName string, r Registry) (*Client, error) {
 
 func nodeToDial(serviceName string, r Registry) (node Node, err error) {
 	serv, err := r.Services(context.Background())
+const defaultMaxConnections = 3
+const defaultInitalNodeTimeout = 5 * time.Second
+
+type connectionBalancer struct {
+	clientNode    string
+	selectedNodes []Node
+	clients       []*rpc.Client
+	seq           uint64
+
+	cancel    func()
+	errChan   chan error
+	waitGroup sync.WaitGroup
+}
+
+func newConnectionBalancer(host string, serviceName string, r Registry) (*connectionBalancer, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	c := &connectionBalancer{
+		clientNode: host,
+		clients:    []*rpc.Client{},
+		cancel:     cancel,
+		errChan:    make(chan error, 1),
+	}
+
+	nodesChan := r.WatchService(ctx, serviceName)
+
+	var initalNodes []Node
+	select {
+	case initalNodes = <-nodesChan:
+	case <-time.After(defaultInitalNodeTimeout):
+		return nil, fmt.Errorf("no inital nodes provided for %v", serviceName)
+	}
+
+	if err := c.handleNewNodes(initalNodes); err != nil {
+		return nil, err
+	}
+
+	c.waitGroup.Add(1)
+	go c.watchForNewNodes(ctx, nodesChan)
+	return c, nil
+}
+
+func (c *connectionBalancer) Get() *rpc.Client {
+	return c.roundRobinSelect()
+}
+
+func (c *connectionBalancer) roundRobinSelect() *rpc.Client {
+	index := atomic.AddUint64(&c.seq, uint64(1))
+	return c.clients[int(index)%len(c.clients)]
+}
+
+func (c *connectionBalancer) Close() error {
+	if c.cancel != nil {
+		c.cancel()
+	}
+	for _, client := range c.clients {
+		client.Close()
+	}
+	c.waitGroup.Wait()
+	close(c.errChan)
+	return nil
+}
+
+func (c *connectionBalancer) watchForNewNodes(ctx context.Context, nodesChan chan []Node) {
+	defer c.waitGroup.Done()
+
+	for {
+		select {
+		case nodes := <-nodesChan:
+			if len(nodes) == 0 {
+				continue
+			}
+
+			if err := c.handleNewNodes(nodes); err != nil {
+				select {
+				case c.errChan <- err:
+				default:
+				}
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (c *connectionBalancer) handleNewNodes(nodes []Node) error {
+	selectedNodes := c.selectNodes(nodes, defaultMaxConnections)
+	clients, err := c.connectToNodes(selectedNodes)
 	if err != nil {
 		return node, err
 	}
@@ -45,8 +136,48 @@ func nodeToDial(serviceName string, r Registry) (node Node, err error) {
 	nodes, ok := serv[serviceName]
 	if !ok || len(nodes) == 0 {
 		return node, fmt.Errorf("failed to find service %v in the registry", serviceName)
+	c.clients = clients
+	c.selectedNodes = selectedNodes
+	return nil
+}
+
+// selectedNodes selects a number of nodes from the list of nodes given.
+// It uses a hashing scheme to determine which index the current node should select.
+// We select up to a max number of connections or what the size of the nodes allows.
+// The current hashing scheme is such:
+//		index n = hash(host + n)
+// Where n the connection number being made.
+func (c *connectionBalancer) selectNodes(nodes []Node, maxConnections int) []Node {
+	if len(nodes) <= maxConnections {
+		return nodes
 	}
 
-	randIndex := rand.Intn(len(nodes))
-	return nodes[randIndex], nil
+	selectedNodes := make([]Node, 0, maxConnections)
+	for i := 0; len(selectedNodes) < maxConnections; i++ {
+		index := c.hashConnectionIndex(i, len(nodes))
+		selectedNodes = append(selectedNodes, nodes[index])
+	}
+
+	return selectedNodes
+}
+
+func (c *connectionBalancer) hashConnectionIndex(connNumber, nodeSize int) int {
+	h := fnv.New32a()
+	h.Write([]byte(c.clientNode + strconv.Itoa(connNumber)))
+	return int(h.Sum32()) % nodeSize
+}
+
+func (c *connectionBalancer) connectToNodes(nodes []Node) ([]*rpc.Client, error) {
+	clients := make([]*rpc.Client, len(nodes))
+
+	for i, node := range nodes {
+		dialAddr := fmt.Sprintf("%v:%v", node.Address, node.Port)
+		client, err := rpc.DialHTTP("tcp", dialAddr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to dial service address %v: %w", dialAddr, err)
+		}
+		clients[i] = client
+	}
+
+	return clients, nil
 }

--- a/cluster/rpc.go
+++ b/cluster/rpc.go
@@ -47,8 +47,8 @@ const defaultMaxConnections = 3
 const defaultInitialNodeTimeout = 5 * time.Second
 
 type connectionBalancer struct {
-	clientNode string
-	seq        uint64
+	localAddr string
+	seq       uint64
 
 	selectedNodes []Node
 	clients       []*rpc.Client
@@ -63,10 +63,10 @@ func newConnectionBalancer(host string, serviceName string, r Registry) (*connec
 	ctx, cancel := context.WithCancel(context.Background())
 
 	c := &connectionBalancer{
-		clientNode: host,
-		clients:    []*rpc.Client{},
-		cancel:     cancel,
-		errChan:    make(chan error, 1),
+		localAddr: host,
+		clients:   []*rpc.Client{},
+		cancel:    cancel,
+		errChan:   make(chan error, 1),
 	}
 
 	nodesChan := r.WatchService(ctx, serviceName)
@@ -167,7 +167,7 @@ func (c *connectionBalancer) selectNodes(nodes []Node, maxConnections int) []Nod
 
 func (c *connectionBalancer) hashConnectionIndex(connNumber, nodeSize int) int {
 	h := fnv.New32a()
-	h.Write([]byte(c.clientNode + strconv.Itoa(connNumber)))
+	h.Write([]byte(c.localAddr + strconv.Itoa(connNumber)))
 	return int(h.Sum32()) % nodeSize
 }
 

--- a/cluster/rpc.go
+++ b/cluster/rpc.go
@@ -44,7 +44,7 @@ func (c *Client) ConnectionErrs() chan error {
 }
 
 const defaultMaxConnections = 3
-const defaultInitalNodeTimeout = 5 * time.Second
+const defaultInitialNodeTimeout = 5 * time.Second
 
 type connectionBalancer struct {
 	clientNode string
@@ -71,14 +71,14 @@ func newConnectionBalancer(host string, serviceName string, r Registry) (*connec
 
 	nodesChan := r.WatchService(ctx, serviceName)
 
-	var initalNodes []Node
+	var initialNodes []Node
 	select {
-	case initalNodes = <-nodesChan:
-	case <-time.After(defaultInitalNodeTimeout):
-		return nil, fmt.Errorf("no inital nodes provided for %v", serviceName)
+	case initialNodes = <-nodesChan:
+	case <-time.After(defaultInitialNodeTimeout):
+		return nil, fmt.Errorf("no initial nodes provided for %v", serviceName)
 	}
 
-	if err := c.handleNewNodes(initalNodes); err != nil {
+	if err := c.handleNewNodes(initialNodes); err != nil {
 		return nil, err
 	}
 

--- a/cluster/rpc_test.go
+++ b/cluster/rpc_test.go
@@ -17,11 +17,11 @@ type mockRegistry struct {
 	nodeChan chan []Node
 }
 
-func newMockRegistry(initalNodes []Node) mockRegistry {
+func newMockRegistry(initialNodes []Node) mockRegistry {
 	mock := mockRegistry{
 		nodeChan: make(chan []Node),
 	}
-	go func() { mock.nodeChan <- initalNodes }()
+	go func() { mock.nodeChan <- initialNodes }()
 	return mock
 }
 
@@ -70,7 +70,7 @@ func TestClient_Call(t *testing.T) {
 	require.Equal(t, "who's joe", reply)
 }
 
-func TestNewConnectionBalancer_successul_inital_connect(t *testing.T) {
+func TestNewConnectionBalancer_successul_initial_connect(t *testing.T) {
 	node, close := testRPCServer(t)
 	defer close()
 

--- a/example/calculator/client/client.go
+++ b/example/calculator/client/client.go
@@ -29,7 +29,7 @@ func main() {
 	}
 	fmt.Printf("client: services %v\n", services)
 
-	client, err := cluster.NewClient("arith", c.Registry)
+	client, err := c.NewClient("calculator")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
# What

This PR adds a client-side load balancing mechanism to the RPC client with the `connectionBalancer` struct. 

# Why

Prior, our RPC client was simple, upon creation it would connect to a single node and use that node until failure. We needed a more fault-tolerant design. 

One common microservice architecture is client-side load balancing. This is usually utilized with a service registry which we have to offload the load balancing to the clients. This design fits our problem particularly well because of the following reasons:

1. Reduces the need for the external dependency of a load balancer
1. We have a service registry in place with the ability to broadcast updates
1. Enables fault tolerance in the form of retries to different nodes, and handles the case where the connected node is down
1. Dynamically scales with the cluster size 

# How

The balancing works by using consistent hashing to determine which service nodes a host should connect to. This connection phase happens each time there is an update to the cluster for that service. From there it round-robins the requests to the connected nodes. I decided to cap the connections at 3 as it seemed like a reasonable number and would be resilient to scale. 

An explanation of the hashing scheme is found here: https://github.com/edegens/ptype/pull/44/files#diff-91162c2fd8a9fa17718d3b54e76090f7R143-R148

A good example of how the system works is in this test: https://github.com/edegens/ptype/pull/44/files#diff-6a683b61d57a7d3b6996aed95500d9d9R102-R140

# Example App

This breaks the example app which will be fixed in a separate PR because of the size of the fix.

# Review

Review by commit would be the easier way. The bulk of the changes are in e081fd0 and 5d05b7a. 