### PR TITLE
Fix Trailing Prefix Get's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ before_script:
 script:
   - golangci-lint run
   - make test
+  - cd example/calculator && ./run

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,3 @@ before_script:
 script:
   - golangci-lint run
   - make test
-  - cd example/calculator && ./run

--- a/cluster/registry.go
+++ b/cluster/registry.go
@@ -61,7 +61,7 @@ func (er *etcdRegistry) Register(ctx context.Context, serviceName, nodeName, hos
 		return fmt.Errorf("failed to create lease for service: %w", err)
 	}
 
-	key := filepath.Join(servicesPrefix, serviceName, nodeName)
+	key := etcdKey(servicesPrefix, serviceName, nodeName)
 	if _, err = er.kv.Put(ctx, key, string(val), clientv3.WithLease(resp.ID)); err != nil {
 		return fmt.Errorf("failed to register node: %w", err)
 	}
@@ -117,7 +117,7 @@ func (er *etcdRegistry) Services(ctx context.Context) (map[string][]Node, error)
 }
 
 func (er *etcdRegistry) WatchService(ctx context.Context, serviceName string) chan []Node {
-	key := filepath.Join(servicesPrefix, serviceName)
+	key := etcdKey(servicesPrefix, serviceName)
 
 	nodesChan := make(chan []Node)
 	watchChan := er.watcher.Watch(ctx, key, clientv3.WithPrefix())
@@ -150,7 +150,7 @@ func (er *etcdRegistry) WatchService(ctx context.Context, serviceName string) ch
 }
 
 func (er *etcdRegistry) nodes(ctx context.Context, serviceName string) ([]Node, error) {
-	key := filepath.Join(servicesPrefix, serviceName)
+	key := etcdKey(servicesPrefix, serviceName)
 	res, err := er.kv.Get(ctx, key, defaultGetOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get services from etcd: %w", err)
@@ -163,4 +163,8 @@ func (er *etcdRegistry) nodes(ctx context.Context, serviceName string) ([]Node, 
 		}
 	}
 	return nodes, nil
+}
+
+func etcdKey(elems ...string) string {
+	return filepath.Join(elems...) + "/"
 }

--- a/cluster/registry_test.go
+++ b/cluster/registry_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -56,7 +55,7 @@ func (suite *EtcdDependentSuite) TestEtcdRegistry_Register() {
 	require.NoError(t, err)
 
 	t.Run("test multiple nodes registered for foo", func(t *testing.T) {
-		key := filepath.Join(servicesPrefix, "foo")
+		key := etcdKey(servicesPrefix, "foo")
 		res, err := sr.kv.Get(ctx, key, defaultGetOptions...)
 		require.NoError(t, err)
 
@@ -72,7 +71,7 @@ func (suite *EtcdDependentSuite) TestEtcdRegistry_Register() {
 	})
 
 	t.Run("test one node registered for bar", func(t *testing.T) {
-		key := filepath.Join(servicesPrefix, "bar")
+		key := etcdKey(servicesPrefix, "bar")
 		res, err := sr.kv.Get(ctx, key, defaultGetOptions...)
 		require.NoError(t, err)
 
@@ -97,13 +96,13 @@ func (suite *EtcdDependentSuite) TestEtcdRegistry_Services() {
 	sr, err := newEtcdRegistry(ctx, suite.testEtcdAddr)
 	require.NoError(t, err)
 
-	key := filepath.Join(servicesPrefix, "foo", "node1")
+	key := etcdKey(servicesPrefix, "foo", "node1")
 	_, err = sr.kv.Put(ctx, key, `{"address":"host", "port":8000}`)
 	require.NoError(t, err)
-	key = filepath.Join(servicesPrefix, "foo", "node2")
+	key = etcdKey(servicesPrefix, "foo", "node2")
 	_, err = sr.kv.Put(ctx, key, `{"address":"host2", "port":8000}`)
 	require.NoError(t, err)
-	key = filepath.Join(servicesPrefix, "bar", "node3")
+	key = etcdKey(servicesPrefix, "bar", "node3")
 	_, err = sr.kv.Put(ctx, key, `{"address":"host3", "port":3000}`)
 	require.NoError(t, err)
 
@@ -139,7 +138,7 @@ func (suite *EtcdDependentSuite) TestServiceRegistry_Leases() {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		key := filepath.Join(servicesPrefix, "bar")
+		key := etcdKey(servicesPrefix, "bar")
 		res, err := sr.kv.Get(ctx, key, defaultGetOptions...)
 		require.NoError(t, err)
 
@@ -156,7 +155,7 @@ func (suite *EtcdDependentSuite) TestEtcdRegistry_WatchService() {
 	sr, err := newEtcdRegistry(ctx, suite.testEtcdAddr)
 	require.NoError(t, err)
 
-	key := filepath.Join(servicesPrefix, "foo", "node1")
+	key := etcdKey(servicesPrefix, "foo", "node1")
 	_, err = sr.kv.Put(ctx, key, `{"address":"host", "port":8000}`)
 	require.NoError(t, err)
 
@@ -169,7 +168,7 @@ func (suite *EtcdDependentSuite) TestEtcdRegistry_WatchService() {
 	})
 
 	t.Run("channel returns all nodes on event change", func(t *testing.T) {
-		key = filepath.Join(servicesPrefix, "foo", "node3")
+		key = etcdKey(servicesPrefix, "foo", "node3")
 		_, err = sr.kv.Put(ctx, key, `{"address":"host3", "port":3000}`)
 		require.NoError(t, err)
 
@@ -180,7 +179,7 @@ func (suite *EtcdDependentSuite) TestEtcdRegistry_WatchService() {
 	})
 
 	t.Run("handles the deletion of a node", func(t *testing.T) {
-		key = filepath.Join(servicesPrefix, "foo", "node1")
+		key = etcdKey(servicesPrefix, "foo", "node1")
 		_, err = sr.kv.Delete(ctx, key)
 		require.NoError(t, err)
 

--- a/example/calculator/client/client.go
+++ b/example/calculator/client/client.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 
-	"github.com/coreos/pkg/capnslog"
 	"github.com/edegens/ptype/cluster"
 	"github.com/edegens/ptype/example/calculator"
 )
@@ -16,7 +15,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	capnslog.SetGlobalLogLevel(capnslog.ERROR)
 
 	c, err := cluster.Join(context.Background(), cfg)
 	if err != nil {

--- a/example/calculator/client/client.go
+++ b/example/calculator/client/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/edegens/ptype/cluster"
 	"github.com/edegens/ptype/example/calculator"
@@ -27,6 +28,8 @@ func main() {
 	}
 	fmt.Printf("client: services %v\n", services)
 
+	// let the http server spin up after etcd
+	time.Sleep(500 * time.Millisecond)
 	client, err := c.NewClient("calculator")
 	if err != nil {
 		log.Fatal(err)

--- a/example/calculator/run
+++ b/example/calculator/run
@@ -1,7 +1,7 @@
 #!/bin/bash
+set -e
 
-trap "exit" INT TERM ERR
-trap "kill 0" EXIT
+trap "kill 0" EXIT INT TERM ERR
 
 CONFIG=./server/calculator_server.yaml go run server/server.go &
 CONFIG=./client/calculator_client.yaml go run client/client.go

--- a/example/calculator/run
+++ b/example/calculator/run
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+trap "exit" INT TERM ERR
+trap "kill 0" EXIT
 
 CONFIG=./server/calculator_server.yaml go run server/server.go &
 CONFIG=./client/calculator_client.yaml go run client/client.go

--- a/example/calculator/server/calculator_server.yaml
+++ b/example/calculator/server/calculator_server.yaml
@@ -1,4 +1,4 @@
 service_name: calculator
 node_name: calculator_node_1
-port: 1234
+port: 31234
 etcd_config_file: calculator_etcd.yaml

--- a/example/calculator/server/server.go
+++ b/example/calculator/server/server.go
@@ -37,5 +37,7 @@ func main() {
 	}
 	fmt.Printf("server: services %v\n", services)
 
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%v", cfg.Port), nil))
+	if err := http.ListenAndServe(fmt.Sprintf(":%v", cfg.Port), nil); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/example/calculator/server/server.go
+++ b/example/calculator/server/server.go
@@ -8,7 +8,6 @@ import (
 	"net/rpc"
 	"os"
 
-	"github.com/coreos/pkg/capnslog"
 	"github.com/edegens/ptype/cluster"
 	"github.com/edegens/ptype/example/calculator"
 )
@@ -24,7 +23,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	capnslog.SetGlobalLogLevel(capnslog.ERROR)
 
 	c, err := cluster.Join(context.Background(), cfg)
 	if err != nil {

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,10 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumC
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-kit/kit v0.9.0 h1:wDJmvq38kDhkVxi50ni9ykkdUr1PKgqKOoi01fa0Mdk=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
+github.com/go-logfmt/logfmt v0.4.0 h1:MP4Eh7ZCb31lleYCFuwm0oe4/YGak+5l1vA2NOE80nA=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=


### PR DESCRIPTION
# What  
Fix trailing prefix case for Gets and Watchers. This prevents a Get for "foo" to include "foo_bar"

# How
Add a "/" to the end of keys. 

# Others
- example run in CI
- handle error in RPC client when no clients available
---

Merge after #44 and change base to master