### PR TITLE
get a single key for store Get

### DIFF
--- a/cluster/store.go
+++ b/cluster/store.go
@@ -35,7 +35,7 @@ func NewKVStore(ctx context.Context, etcdAddr string) (*KVStore, error) {
 
 // Get returns the best matched value for the key provided
 func (kvs *KVStore) Get(ctx context.Context, key string) (string, error) {
-	getres, err := kvs.kv.Get(ctx, fmt.Sprintf("%s/%s", storePrefix, key), defaultGetOptions...)
+	getres, err := kvs.kv.Get(ctx, etcdKey(storePrefix, key), defaultGetOptions...)
 	if err != nil {
 		return "", fmt.Errorf("failed to get key %s: %w", key, err)
 	}

--- a/cluster/store_test.go
+++ b/cluster/store_test.go
@@ -35,12 +35,12 @@ func (suite *EtcdDependentSuite) TestKVGet() {
 
 	tmpKV := clientv3.NewKV(c)
 	expected := "uwu1"
-	_, err = tmpKV.Put(ctx, "store/raccoon1", expected)
+	_, err = tmpKV.Put(ctx, "store/raccoon1/", expected)
 	require.NoError(t, err)
-	_, err = tmpKV.Put(ctx, "store/raccoon2", "uwu2")
+	_, err = tmpKV.Put(ctx, "store/raccoon2/", "uwu2")
 	require.NoError(t, err)
 
-	val, err := kvs.Get(ctx, "raccoon")
+	val, err := kvs.Get(ctx, "raccoon1")
 	require.NoError(t, err)
 	require.Equal(t, expected, val, "value read back should be the same")
 }


### PR DESCRIPTION
uses `etcdKey` instead of `filePath.Join` to append a `/` at the end so only 1 key can be returned.