### PR TITLE
add KV put, delete, and test

### DIFF
--- a/cluster/store.go
+++ b/cluster/store.go
@@ -11,7 +11,7 @@ import (
 const storePrefix = "store"
 
 var (
-	ErrNoKey = errors.New("Key does not exist in store")
+	ErrNoKey = errors.New("Key could not be found")
 )
 
 type KVStore struct {
@@ -63,4 +63,25 @@ func (kvs *KVStore) GetPrefix(ctx context.Context, key string) ([]string, error)
 	}
 
 	return gets, nil
+}
+
+// Put sets the value for the given key
+func (kvs *KVStore) Put(ctx context.Context, key, value string) error {
+	_, err := kvs.kv.Put(ctx, etcdKey(storePrefix, key), value)
+	if err != nil {
+		return fmt.Errorf("failed to put (key, value) (%s, %s): %w", key, value, err)
+	}
+	return nil
+}
+
+// Delete deletes the given key
+func (kvs *KVStore) Delete(ctx context.Context, key string) error {
+	delres, err := kvs.kv.Delete(ctx, etcdKey(storePrefix, key))
+	if err != nil {
+		return fmt.Errorf("failed to delete key %s: %w", key, err)
+	}
+	if delres.Deleted == 0 {
+		return ErrNoKey
+	}
+	return nil
 }

--- a/cluster/store_test.go
+++ b/cluster/store_test.go
@@ -116,7 +116,8 @@ func (suite *EtcdDependentSuite) TestKVPut() {
 	require.NoError(t, err)
 
 	expected := "world"
-	kvs.Put(ctx, "hello", expected)
+	err = kvs.Put(ctx, "hello", expected)
+	require.NoError(t, err)
 
 	val, err := kvs.Get(ctx, "hello")
 	require.Equal(t, val, expected, "val returned should be expected")
@@ -134,7 +135,8 @@ func (suite *EtcdDependentSuite) TestKVDelete() {
 	require.NoError(t, err)
 
 	expected := "world"
-	kvs.Put(ctx, "hello", expected)
+	err = kvs.Put(ctx, "hello", expected)
+	require.NoError(t, err)
 
 	err = kvs.Delete(ctx, "hello")
 	require.NoError(t, err)

--- a/cluster/store_test.go
+++ b/cluster/store_test.go
@@ -104,3 +104,56 @@ func (suite *EtcdDependentSuite) TestKVGetPrefixErrorsOnNoKey() {
 	require.Equal(t, ErrNoKey, err, "error returned should be ErrNoKey")
 	require.Nil(t, val)
 }
+
+func (suite *EtcdDependentSuite) TestKVPut() {
+	suite.SetupTest()
+	t := suite.T()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kvs, err := NewKVStore(ctx, suite.testEtcdAddr)
+	require.NoError(t, err)
+
+	expected := "world"
+	kvs.Put(ctx, "hello", expected)
+
+	val, err := kvs.Get(ctx, "hello")
+	require.Equal(t, val, expected, "val returned should be expected")
+	require.NoError(t, err)
+}
+
+func (suite *EtcdDependentSuite) TestKVDelete() {
+	suite.SetupTest()
+	t := suite.T()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kvs, err := NewKVStore(ctx, suite.testEtcdAddr)
+	require.NoError(t, err)
+
+	expected := "world"
+	kvs.Put(ctx, "hello", expected)
+
+	err = kvs.Delete(ctx, "hello")
+	require.NoError(t, err)
+
+	val, err := kvs.Get(ctx, "hello")
+	require.Equal(t, err, ErrNoKey, "no key should be left after deletion")
+	require.Equal(t, val, "")
+}
+
+func (suite *EtcdDependentSuite) TestKVDeleteNoKey() {
+	suite.SetupTest()
+	t := suite.T()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kvs, err := NewKVStore(ctx, suite.testEtcdAddr)
+	require.NoError(t, err)
+
+	err = kvs.Delete(ctx, "hello")
+	require.Equal(t, err, ErrNoKey, "no key to delete should yield ErrNoKey")
+}


### PR DESCRIPTION
Fixes #52 

This PR makes it so developers can `Put` and `Delete` from the store. It is quick and dirty.

I am not the happiest with these. I want to have an API that is simple, and doesn't limit what etcd itself gives. Ideally we want to pass through `OpOptions` or something similar. This will come in a different PR that will address the issue #19 

However, this PR unblocks the demo.