### PR TITLE
Log Leases With Zap

### DIFF
--- a/cluster/registry.go
+++ b/cluster/registry.go
@@ -74,11 +74,11 @@ func (er *etcdRegistry) Register(ctx context.Context, serviceName, nodeName, hos
 		for {
 			kar := <-keepAliveResp
 			if kar == nil {
-				fmt.Printf("service %s failed to refresh \n", serviceName)
+				zap.S().Warnw("service failed to refresh", "service", serviceName)
 				break
 
 			}
-			fmt.Printf("service %s refreshed and vaild for(ttl): %d \n", serviceName, kar.TTL)
+			zap.S().Infow("service ttl refreshed", "service", serviceName, "ttl", kar.TTL)
 		}
 	}()
 


### PR DESCRIPTION
The lease logs are using `fmt.Print` right now. This PR makes it consistent with the other logs in the package.
