### PR TITLE
RPC Config Per Client

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -103,8 +103,8 @@ func (c *Cluster) Close() error {
 	return nil
 }
 
-func (c *Cluster) NewClient(serviceName string) (*Client, error) {
-	return newClient(c.localAddr, serviceName, c.Registry)
+func (c *Cluster) NewClient(serviceName string, cfg *ConnConfig) (*Client, error) {
+	return newClient(c.localAddr, serviceName, c.Registry, cfg)
 }
 
 func memberAdd(ctx context.Context, client *clientv3.Client, cfg embed.Config) (string, error) {

--- a/cluster/rpc_test.go
+++ b/cluster/rpc_test.go
@@ -56,6 +56,13 @@ var testConnConfig = &ConnConfig{
 	DebounceTime:       time.Second,
 }
 
+func TestClient_default_conn_config(t *testing.T) {
+	mock := newMockRegistry([]Node{})
+	c, err := newClient("", "foo", &mock, nil)
+	require.NoError(t, err)
+	require.Equal(t, DefaultConnConfig, c.conns.cfg)
+}
+
 func TestClient_Call(t *testing.T) {
 	ts := rpc.NewServer()
 	err := ts.Register(new(RPCTest))

--- a/cluster/rpc_test.go
+++ b/cluster/rpc_test.go
@@ -50,6 +50,12 @@ func (r *RPCTest) Go(x string, y *string) error {
 	return nil
 }
 
+var testConnConfig = &ConnConfig{
+	MaxConnections:     DefaultConnConfig.MaxConnections,
+	InitialNodeTimeout: time.Second,
+	DebounceTime:       time.Second,
+}
+
 func TestClient_Call(t *testing.T) {
 	ts := rpc.NewServer()
 	err := ts.Register(new(RPCTest))
@@ -66,7 +72,7 @@ func TestClient_Call(t *testing.T) {
 		Port:    l.Addr().(*net.TCPAddr).Port,
 	}
 	mock := newMockRegistry([]Node{node})
-	c, err := newClient("", "foo", &mock)
+	c, err := newClient("", "foo", &mock, testConnConfig)
 	require.NoError(t, err)
 	defer c.Close()
 
@@ -92,7 +98,7 @@ func TestClient_Go(t *testing.T) {
 		Port:    l.Addr().(*net.TCPAddr).Port,
 	}
 	mock := newMockRegistry([]Node{node})
-	c, err := newClient("", "foo", &mock)
+	c, err := newClient("", "foo", &mock, testConnConfig)
 	require.NoError(t, err)
 	defer c.Close()
 
@@ -110,7 +116,7 @@ func TestNewConnectionBalancer_successul_initial_connect(t *testing.T) {
 	defer close()
 
 	mock := newMockRegistry([]Node{node})
-	c, err := newConnectionBalancer("", "foo", &mock)
+	c, err := newConnectionBalancer("", "foo", &mock, testConnConfig)
 	require.NoError(t, err)
 	defer c.Close()
 
@@ -122,14 +128,14 @@ func TestNewConnectionBalancer_with_no_available_server(t *testing.T) {
 	mock := mockRegistry{
 		nodeChan: make(chan []Node),
 	}
-	c, err := newConnectionBalancer("", "foo", &mock)
+	c, err := newConnectionBalancer("", "foo", &mock, testConnConfig)
 	require.Error(t, err)
 	require.Nil(t, c)
 }
 
 func TestNewConnectionBalancer_with_servers_failing_to_connect(t *testing.T) {
 	mock := newMockRegistry([]Node{{Address: "127.0.0.1", Port: 1234}})
-	c, err := newConnectionBalancer("", "foo", &mock)
+	c, err := newConnectionBalancer("", "foo", &mock, testConnConfig)
 	require.Error(t, err)
 	require.Nil(t, c)
 }
@@ -139,7 +145,7 @@ func TestConnectionBalancer_watchForNewNodes(t *testing.T) {
 	defer close()
 	mock := newMockRegistry([]Node{node})
 
-	c, err := newConnectionBalancer("", "foo", &mock)
+	c, err := newConnectionBalancer("", "foo", &mock, testConnConfig)
 	require.NoError(t, err)
 	defer c.Close()
 

--- a/example/calculator/client/client.go
+++ b/example/calculator/client/client.go
@@ -30,7 +30,7 @@ func main() {
 
 	// let the http server spin up after etcd
 	time.Sleep(500 * time.Millisecond)
-	client, err := c.NewClient("calculator")
+	client, err := c.NewClient("calculator", nil)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
closes #48 

# What
This PR allows users to create clients to have control of the RPC connections. 

# How
Client method accepts config struct. A default one is supplied if one isn't provided. 