### PR TITLE
Retry on Different Node

### DIFF
--- a/cluster/rpc.go
+++ b/cluster/rpc.go
@@ -201,7 +201,7 @@ func (c *connectionBalancer) handleNewNodes(nodes []Node) error {
 //		index n = hash(host + n)
 // Where n the connection number being made.
 func (c *connectionBalancer) selectNodes(nodes []Node, maxConnections int) []Node {
-	if len(nodes) <= maxConnections {
+	if len(nodes) <= maxConnections || maxConnections == 0 {
 		return nodes
 	}
 

--- a/cluster/rpc.go
+++ b/cluster/rpc.go
@@ -34,7 +34,7 @@ var DefaultConnConfig = &ConnConfig{
 	MaxConnections:     3,
 	InitialNodeTimeout: 5 * time.Second,
 	DebounceTime:       3 * time.Second,
-	Retries:            1,
+	Retries:            2,
 }
 
 type Client struct {

--- a/cluster/rpc_test.go
+++ b/cluster/rpc_test.go
@@ -2,9 +2,11 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"net/rpc"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -50,6 +52,30 @@ func (r *RPCTest) Go(x string, y *string) error {
 	return nil
 }
 
+type RPCRetryTest struct {
+	called          uint32
+	callsBeforePass uint32
+}
+
+func (r *RPCRetryTest) Call(arg string, called *int) error {
+	atomic.AddUint32(&r.called, 1)
+	if r.called >= r.callsBeforePass {
+		*called = int(r.called)
+		return nil
+	}
+	return errors.New("failed")
+}
+
+func (r *RPCRetryTest) Go(arg string, called *int) error {
+	time.Sleep(time.Second)
+	atomic.AddUint32(&r.called, 1)
+	if r.called >= r.callsBeforePass {
+		*called = int(r.called)
+		return nil
+	}
+	return errors.New("failed")
+}
+
 var testConnConfig = &ConnConfig{
 	MaxConnections:     DefaultConnConfig.MaxConnections,
 	InitialNodeTimeout: time.Second,
@@ -89,6 +115,76 @@ func TestClient_Call(t *testing.T) {
 	require.Equal(t, "who's joe", reply)
 }
 
+func TestClient_Call_with_retry_multi_node(t *testing.T) {
+	ts1 := rpc.NewServer()
+	err := ts1.Register(&RPCRetryTest{callsBeforePass: 2})
+	require.NoError(t, err)
+
+	ts2 := rpc.NewServer()
+	err = ts2.Register(&RPCRetryTest{callsBeforePass: 0})
+	require.NoError(t, err)
+
+	l1, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l1.Close()
+
+	go func() { _ = http.Serve(l1, ts1) }()
+
+	l2, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l1.Close()
+
+	go func() { _ = http.Serve(l2, ts2) }()
+
+	mock := newMockRegistry([]Node{
+		{
+			Address: "127.0.0.1",
+			Port:    l1.Addr().(*net.TCPAddr).Port,
+		},
+		{
+			Address: "127.0.0.1",
+			Port:    l2.Addr().(*net.TCPAddr).Port,
+		},
+	})
+
+	c, err := newClient("", "foo", &mock, testConnConfig)
+	require.NoError(t, err)
+	defer c.Close()
+
+	var calls int
+	err = c.Call("RPCRetryTest.Call", "", &calls)
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+}
+
+func TestClient_Call_with_retry_error(t *testing.T) {
+	ts1 := rpc.NewServer()
+	err := ts1.Register(&RPCRetryTest{callsBeforePass: 10})
+	require.NoError(t, err)
+
+	l1, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l1.Close()
+
+	go func() { _ = http.Serve(l1, ts1) }()
+
+	mock := newMockRegistry([]Node{
+		{
+			Address: "127.0.0.1",
+			Port:    l1.Addr().(*net.TCPAddr).Port,
+		},
+	})
+
+	c, err := newClient("", "foo", &mock, testConnConfig)
+	require.NoError(t, err)
+	defer c.Close()
+
+	var calls int
+	err = c.Call("RPCRetryTest.Call", "", &calls)
+	require.Error(t, err)
+	require.Equal(t, 0, calls)
+}
+
 func TestClient_Go(t *testing.T) {
 	ts := rpc.NewServer()
 	err := ts.Register(new(RPCTest))
@@ -116,6 +212,83 @@ func TestClient_Go(t *testing.T) {
 
 	<-call.Done
 	require.Equal(t, "who's joe", reply)
+}
+
+func TestClient_Go_with_retry_multi_node(t *testing.T) {
+	ts1 := rpc.NewServer()
+	err := ts1.Register(&RPCRetryTest{callsBeforePass: 2})
+	require.NoError(t, err)
+
+	ts2 := rpc.NewServer()
+	err = ts2.Register(&RPCRetryTest{callsBeforePass: 0})
+	require.NoError(t, err)
+
+	l1, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l1.Close()
+
+	go func() { _ = http.Serve(l1, ts1) }()
+
+	l2, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l1.Close()
+
+	go func() { _ = http.Serve(l2, ts2) }()
+
+	mock := newMockRegistry([]Node{
+		{
+			Address: "127.0.0.1",
+			Port:    l1.Addr().(*net.TCPAddr).Port,
+		},
+		{
+			Address: "127.0.0.1",
+			Port:    l2.Addr().(*net.TCPAddr).Port,
+		},
+	})
+
+	c, err := newClient("", "foo", &mock, testConnConfig)
+	require.NoError(t, err)
+	defer c.Close()
+
+	var calls int
+	call := c.Go("RPCRetryTest.Go", "", &calls, nil)
+	require.NotNil(t, call)
+	require.NoError(t, call.Error)
+
+	<-call.Done
+	require.Equal(t, 1, calls)
+}
+
+func TestClient_Go_with_retry_error(t *testing.T) {
+	ts1 := rpc.NewServer()
+	err := ts1.Register(&RPCRetryTest{callsBeforePass: 10})
+	require.NoError(t, err)
+
+	l1, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l1.Close()
+
+	go func() { _ = http.Serve(l1, ts1) }()
+
+	mock := newMockRegistry([]Node{
+		{
+			Address: "127.0.0.1",
+			Port:    l1.Addr().(*net.TCPAddr).Port,
+		},
+	})
+
+	c, err := newClient("", "foo", &mock, testConnConfig)
+	require.NoError(t, err)
+	defer c.Close()
+
+	var calls int
+	call := c.Go("RPCRetryTest.Go", "", &calls, nil)
+	require.NotNil(t, call)
+	require.NoError(t, call.Error)
+
+	resp := <-call.Done
+	require.Error(t, resp.Error)
+	require.Equal(t, 0, calls)
 }
 
 func TestNewConnectionBalancer_successul_initial_connect(t *testing.T) {


### PR DESCRIPTION
closes #49 
blocked on #60 

# What

This PR allows for 2 features. 
1. Mesh networks by setting max connection = 0
2. Retries on different nodes

# How

1. Mesh network is created by connecting to all service nodes
2. The retries ask for a new connection when retrying a request that errored out. It does not guarantee that a new node will be used. I personally don't think it's worth the effort to guarantee this. 