### PR TITLE
Init KV Store on join

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -61,6 +61,11 @@ func Join(ctx context.Context, cfg Config) (*Cluster, error) {
 		return nil, err
 	}
 
+	store, err := newKVStore(ctx, clientUrls)
+	if err != nil {
+		return nil, err
+	}
+
 	addr, err := getIP()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read hostname: %w", err)
@@ -71,6 +76,7 @@ func Join(ctx context.Context, cfg Config) (*Cluster, error) {
 
 	return &Cluster{
 		Registry:  registry,
+		Store:     store,
 		client:    localClient,
 		etcd:      e,
 		localAddr: addr,

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -19,7 +19,7 @@ type KVStore struct {
 	kv clientv3.KV
 }
 
-func NewKVStore(ctx context.Context, etcdAddrs []string) (*KVStore, error) {
+func newKVStore(ctx context.Context, etcdAddrs []string) (*KVStore, error) {
 	cfg := clientv3.Config{
 		Endpoints:   etcdAddrs,
 		DialTimeout: 5 * time.Second,

--- a/cluster/store_test.go
+++ b/cluster/store_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNewKVStore(t *testing.T) {
-	store, err := NewKVStore(context.Background(), []string{""})
+	store, err := newKVStore(context.Background(), []string{""})
 	require.NoError(t, err)
 	require.NotNil(t, store)
 }
@@ -21,7 +21,7 @@ func (suite *EtcdDependentSuite) TestKVGet() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	kvs, err := NewKVStore(ctx, suite.testEtcdAddr)
+	kvs, err := newKVStore(ctx, suite.testEtcdAddr)
 	require.NoError(t, err)
 
 	// set up raw connection for test setup
@@ -52,7 +52,7 @@ func (suite *EtcdDependentSuite) TestKVGetErrorsOnNoKey() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	kvs, err := NewKVStore(ctx, suite.testEtcdAddr)
+	kvs, err := newKVStore(ctx, suite.testEtcdAddr)
 	require.NoError(t, err)
 
 	vals, err := kvs.Get(ctx, "raccoon")
@@ -67,7 +67,7 @@ func (suite *EtcdDependentSuite) TestKVGetWithPrefix() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	kvs, err := NewKVStore(ctx, suite.testEtcdAddr)
+	kvs, err := newKVStore(ctx, suite.testEtcdAddr)
 	require.NoError(t, err)
 
 	// set up raw connection for test setup
@@ -97,7 +97,7 @@ func (suite *EtcdDependentSuite) TestKVGetWithMultipleOptions() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	kvs, err := NewKVStore(ctx, suite.testEtcdAddr)
+	kvs, err := newKVStore(ctx, suite.testEtcdAddr)
 	require.NoError(t, err)
 
 	expected := []string{"world1", "world2"}
@@ -120,7 +120,7 @@ func (suite *EtcdDependentSuite) TestKVPut() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	kvs, err := NewKVStore(ctx, suite.testEtcdAddr)
+	kvs, err := newKVStore(ctx, suite.testEtcdAddr)
 	require.NoError(t, err)
 
 	expected := "world"
@@ -139,7 +139,7 @@ func (suite *EtcdDependentSuite) TestKVDelete() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	kvs, err := NewKVStore(ctx, suite.testEtcdAddr)
+	kvs, err := newKVStore(ctx, suite.testEtcdAddr)
 	require.NoError(t, err)
 
 	expected := "world"
@@ -161,7 +161,7 @@ func (suite *EtcdDependentSuite) TestKVDeleteNoKey() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	kvs, err := NewKVStore(ctx, suite.testEtcdAddr)
+	kvs, err := newKVStore(ctx, suite.testEtcdAddr)
 	require.NoError(t, err)
 
 	err = kvs.Delete(ctx, "hello")


### PR DESCRIPTION
I forgot to add this... I realized this when making the API.
Code is already be covered by `cluster_test.go#TestJoin()` and `store_test.go#TestNewKVStore()`